### PR TITLE
Bug fix "Can't find class for driver: oracle.jdbc.pool.OracleDataSour…

### DIFF
--- a/src/org/ash/conn/model/Model.java
+++ b/src/org/ash/conn/model/Model.java
@@ -202,6 +202,9 @@ public class Model {
             else if(tmpVersion.substring(16, 18).equalsIgnoreCase("12")) {
                 setVersionDB("11g");
             }
+            else {
+                setVersionDB("11g");
+            }
 		}
 
 	/**


### PR DESCRIPTION
Bug fix "Can't find class for driver: oracle.jdbc.pool.OracleDataSource" for Olacle 18c and higher (ojdbc7)