### PR TITLE
build: bump lombok to 1.18.34 (JDK 21 compat) and auto-copy bc-fips to target/

### DIFF
--- a/ashv/pom.xml
+++ b/ashv/pom.xml
@@ -86,7 +86,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.24</version>
+                            <version>1.18.34</version>
                         </path>
                         <path>
                             <groupId>com.google.auto.factory</groupId>
@@ -121,6 +121,33 @@
                         <goals>
                             <goal>single</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-bc-fips</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.bouncycastle</groupId>
+                                    <artifactId>bc-fips</artifactId>
+                                    <version>1.0.2.4</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.24</version>
+            <version>1.18.34</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -183,7 +183,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.24</version>
+                            <version>1.18.34</version>
                         </path>
                         <path>
                             <groupId>com.google.auto.factory</groupId>


### PR DESCRIPTION
## Summary

Two small, related build fixes so that `mvn clean package -DskipTests` produces a jar that compiles on modern JDKs and runs straight away — no manual steps required.

- **Bump Lombok 1.18.24 → 1.18.34.** Lombok 1.18.24 reaches into internal `javac` AST types. JDK 16 renamed `JCTree$JCImport.qualid`, so on JDK 16+ compilation fails with:
  ```
  java.lang.NoSuchFieldError: Class com.sun.tools.javac.tree.JCTree$JCImport
  does not have member field 'com.sun.tools.javac.tree.JCTree qualid'
  ```
  Lombok 1.18.30 was the first release to handle the rename; 1.18.34 is current stable. Verified building cleanly on JDK 21.

- **Auto-copy `bc-fips-1.0.2.4.jar` to `ashv/target/` during `prepare-package`.** The assembly plugin already writes `Class-Path: bc-fips-1.0.2.4.jar` into the fat jar's manifest (intentionally, since FIPS rules forbid shading the provider), but that file isn't placed next to the jar by the build. As a result, every fresh `mvn clean package` produces a jar that fails at startup with:
  ```
  NoClassDefFoundError: org/bouncycastle/jcajce/provider/BouncyCastleFipsProvider
  ```
  This PR adds a `maven-dependency-plugin` `copy` execution that drops the bc-fips artifact next to the fat jar automatically, matching the Class-Path entry. No user-visible change other than the build now being self-contained.

## Why one commit

The two changes are tightly coupled: together they make `java -jar ashv-…-jar-with-dependencies.jar` actually work after a clean checkout on JDK 21. Happy to split into two commits if preferred — let me know.

## Compatibility

- Lombok 1.18.30+ still supports the JDK 8/11 baseline (release notes confirm), so the bump doesn't raise the minimum JDK.
- The bc-fips artifact and version are unchanged — same jar, just placed for the user automatically.
- No source-code changes, no behavioral changes to the application.

## Test plan

- [x] `mvn clean package -DskipTests` on JDK 21 (Debian 13) → BUILD SUCCESS, `ashv-4.0-SNAPSHOT-jar-with-dependencies.jar` and `bc-fips-1.0.2.4.jar` both in `ashv/target/`
- [x] `java -jar ashv/target/ashv-4.0-SNAPSHOT-jar-with-dependencies.jar` starts the Swing UI without errors
- [x] Connected to an Oracle 23ai PDB via thin JDBC and read `V$ACTIVE_SESSION_HISTORY` end-to-end
- [ ] Build on JDK 11 (please verify if you have it handy — I no longer do)

cc @akardapolov — would love your take.